### PR TITLE
feat: MainScreen.kt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
 
     //implementation(libs.firebase.auth.ktx)
-
+    implementation("io.coil-kt:coil-compose:2.6.0")
 
     // Testing Dependencies
     testImplementation(libs.junit)

--- a/app/src/main/java/com/ippo/taskflow/screen/MainScreen.kt
+++ b/app/src/main/java/com/ippo/taskflow/screen/MainScreen.kt
@@ -1,0 +1,473 @@
+package com.ippo.taskflow.screen
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.ippo.taskflow.auth.AuthViewModel
+import com.ippo.taskflow.data.Task
+import com.ippo.taskflow.task.TaskViewModel
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.map
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import androidx.compose.runtime.collectAsState
+
+// 메인 색상들 (Figma 참고용)
+private val TaskFlowGreen = Color(0xFF1E8A3B)
+private val TaskFlowLightGreen = Color(0xFFE0FFE8)
+private val TaskCardBackground = Color(0xFFFDF9FF)
+
+@Composable
+fun MainScreen(
+    authViewModel: AuthViewModel,
+    taskViewModel: TaskViewModel,
+    onNavigateToSettings: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+    onNavigateToGroups: () -> Unit,
+) {
+    // ----- ViewModel State Observe -----
+    val firebaseUser by authViewModel.currentUser.collectAsState()
+    val profile by authViewModel.profile.collectAsState()
+
+    val taskList by taskViewModel.taskList.collectAsState()
+    val isLoadingTasks by taskViewModel.isLoading.collectAsState()
+    val taskError by taskViewModel.error.collectAsState()
+
+    // 이름: User 프로필 → FirebaseUser.displayName 순으로 우선 사용
+    val userName = when {
+        !profile?.name.isNullOrBlank() -> profile!!.name
+        !firebaseUser?.displayName.isNullOrBlank() -> firebaseUser!!.displayName!!
+        else -> "사용자"
+    }
+
+    // 사진 URL (없으면 null → 기본 아바타 렌더링)
+    val photoUrl = firebaseUser?.photoUrl?.toString()
+
+    // 완료율 계산
+    val totalTasks = taskList.size
+    val completedTasks = taskList.count { it.status.uppercase(Locale.getDefault()) == "DONE" }
+    val completionRatio = if (totalTasks == 0) 0f else completedTasks.toFloat() / totalTasks.toFloat()
+    val completionPercentage = (completionRatio * 100).toInt()
+
+    Scaffold(
+        bottomBar = {
+            MainBottomNavBar(
+                onHomeClick = { /* 현재 화면이므로 아무 동작 없음 */ },
+                onGroupsClick = onNavigateToGroups,
+                onProfileClick = onNavigateToProfile
+            )
+        }
+    ) { innerPadding ->
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                // 상단 헤더
+                MainHeader(
+                    userName = userName,
+                    photoUrl = photoUrl,
+                    onSettingsClick = onNavigateToSettings
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 진행률 대시보드
+                ProgressDashboard(
+                    completionPercentage = completionPercentage
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Task 목록 제목
+                Text(
+                    text = "오늘의 Task",
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Task 목록 리스트
+                TaskListSection(
+                    tasks = taskList,
+                    isLoading = isLoadingTasks,
+                    errorMessage = taskError,
+                    onTaskStatusToggle = { task ->
+                        val newStatus =
+                            if (task.status.uppercase(Locale.getDefault()) == "DONE") "TODO" else "DONE"
+                        taskViewModel.updateTaskStatus(task.taskId, newStatus)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MainHeader(
+    userName: String,
+    photoUrl: String?,
+    onSettingsClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            // 프로필 사진 / 기본 아바타
+            if (photoUrl != null) {
+                AsyncImage(
+                    model = photoUrl,
+                    contentDescription = "Profile Image",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(TaskFlowGreen),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = userName.firstOrNull()?.toString() ?: "U",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column {
+                Text(
+                    text = "안녕!",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Gray
+                )
+                Text(
+                    text = userName,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 20.sp
+                    )
+                )
+            }
+        }
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { /* 알림 기능은 추후 구현 (Placeholder) */ }) {
+                Icon(
+                    imageVector = Icons.Default.Notifications,
+                    contentDescription = "알림",
+                    tint = Color.Black
+                )
+            }
+            IconButton(onClick = onSettingsClick) {
+                Icon(
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = "설정",
+                    tint = Color.Black
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProgressDashboard(
+    completionPercentage: Int,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = TaskFlowGreen
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                modifier = Modifier.weight(1.2f)
+            ) {
+                Text(
+                    text = "오늘의 Task가 거의\n완료됐어요!",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
+                    )
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Card(
+                    shape = RoundedCornerShape(50),
+                    colors = CardDefaults.cardColors(
+                        containerColor = Color.White
+                    )
+                ) {
+                    Text(
+                        text = "TaskFlow",
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
+                        color = TaskFlowGreen,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Box(
+                modifier = Modifier
+                    .size(90.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    progress = completionPercentage / 100f,
+                    modifier = Modifier.fillMaxSize(),
+                    color = Color.White,
+                    strokeWidth = 8.dp,
+                    trackColor = Color.White.copy(alpha = 0.2f)
+                )
+                Text(
+                    text = "$completionPercentage%",
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaskListSection(
+    tasks: List<Task>,
+    isLoading: Boolean,
+    errorMessage: String?,
+    onTaskStatusToggle: (Task) -> Unit,
+) {
+    if (isLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "로딩 중...", color = Color.Gray)
+        }
+        return
+    }
+
+    if (!errorMessage.isNullOrBlank()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = errorMessage, color = Color.Red, fontSize = 12.sp)
+        }
+    }
+
+    if (tasks.isEmpty()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "오늘 등록된 Task가 없습니다.", color = Color.Gray)
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = 80.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        items(tasks, key = { it.taskId }) { task ->
+            TaskCard(
+                task = task,
+                onToggleStatus = { onTaskStatusToggle(task) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun TaskCard(
+    task: Task,
+    onToggleStatus: () -> Unit,
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 왼쪽 아이콘(카테고리 대신 Task 아이콘)
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(TaskFlowLightGreen),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "📌",
+                    fontSize = 20.sp
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = task.title.ifBlank { "제목 없음" },
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.SemiBold
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                val dueText = formatDueDate(task.dueDate)
+                val priorityText = "우선순위 ${task.priority}"
+
+                Text(
+                    text = listOfNotNull(dueText, priorityText).joinToString(" • "),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            IconButton(onClick = onToggleStatus) {
+                val isDone =
+                    task.status.uppercase(Locale.getDefault()) == "DONE"
+                Icon(
+                    imageVector = if (isDone) Icons.Filled.CheckCircle else Icons.Outlined.CheckCircle,
+                    contentDescription = if (isDone) "완료" else "미완료",
+                    tint = if (isDone) TaskFlowGreen else Color.LightGray
+                )
+            }
+        }
+    }
+}
+
+private fun formatDueDate(date: Date?): String? {
+    if (date == null) return null
+    val formatter = SimpleDateFormat("a hh:mm", Locale.getDefault())
+    return formatter.format(date)
+}
+
+@Composable
+private fun MainBottomNavBar(
+    onHomeClick: () -> Unit,
+    onGroupsClick: () -> Unit,
+    onProfileClick: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 8.dp,
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(TaskFlowLightGreen)
+                .padding(horizontal = 40.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onHomeClick) {
+                Icon(
+                    imageVector = Icons.Filled.Home,
+                    contentDescription = "Home",
+                    tint = TaskFlowGreen
+                )
+            }
+            IconButton(onClick = onGroupsClick) {
+                Icon(
+                    imageVector = Icons.Filled.Group,
+                    contentDescription = "Groups",
+                    tint = Color.Black
+                )
+            }
+            IconButton(onClick = onProfileClick) {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = "Profile",
+                    tint = Color.Black
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
📌 MainScreen 기능 개발 – MVVM 구조 기반 UI & ViewModel 연동 추가

✅ 개요 (Overview)
이번 PR에서는 기존 프로젝트 구조에 맞추어 MainScreen UI를 완전 구현하고, 이를 AuthViewModel + TaskViewModel 상태(StateFlow) 와 연동하여 실제 데이터가 반영되는 메인 홈 화면을 구축했습니다.
또한 Figma 디자인을 그대로 반영하여 UI 일관성을 높였으며, Task 상태 업데이트, 진행률 표시, User 프로필 연동 등 핵심 기능 전체를 MVVM 규칙을 준수하며 구현했습니다.

------------------------------------------------------------

🔧 주요 변경 사항 (Key Changes)

1. 메인 화면 Composable 구조 전체 구현
- MainScreen(), MainHeader(), ProgressDashboard(), TaskListSection(), TaskCard(), MainBottomNavBar() 등 화면을 모듈화하여 구성.
- Figma UI를 그대로 반영해 시각적 일관성 확보.

2. ViewModel 상태(StateFlow) 연동 및 반응형 UI 구현

[Auth 연동]
- AuthViewModel.currentUser 와 AuthViewModel.profile Observe.
- 프로필 사진, 사용자 이름, 기본 사용자 아바타 UI 구현.
- Email/Password 사용자 지원을 위해 Firestore User.name → FirebaseUser.displayName 순서로 이름 우선 적용.

[Task 연동]
- TaskViewModel.taskList, isLoading, error Observe.
- Task 목록 렌더링 (LazyColumn).
- Task 완료 여부(DONE/TODO)에 따라 체크 UI 및 색상 업데이트.
- 토글 시 → taskViewModel.updateTaskStatus(taskId, newStatus) 호출하도록 연결.

3. 진행률 대시보드(ProgressDashboard) 구현
- 전체 Task 중 완료 Task 비율을 계산하여 CircularProgressIndicator에 반영.
- completionPercentage UI 표시.
- Figma와 동일한 레이아웃 및 색상 구성.

4. Task 목록 UI 구현
- TaskCard 구성: 아이콘, 제목, 시간, 우선순위, 상태 토글 아이콘.
- Task가 없거나 로딩 중일 때 표시되는 Placeholder 추가.

5. Bottom Navigation Bar 구현
- Home / Groups / Profile 메뉴 구성.
- Navigation은 MainActivity에서 제공하는 callback 기반으로 실행되며 → View는 네비게이션 객체 직접 접근 금지 (MVVM 규칙 유지).

------------------------------------------------------------

🔍 테스트 사항 (Test & Verification)

✔ UI 테스트 (TestActivity 사용)
- Task 목록 정상 표시 확인.
- Task 상태 변경(DONE ↔ TODO) 시 UI 반영 확인.
- User Name / 기본 아바타 / 프로필 사진 로딩 정상 동작 확인.
- Group / Profile / Settings 버튼 클릭 시 Navigation Callback 정상 호출됨.

✔ ViewModel 연동 테스트
- taskList 변경 시 LazyColumn 자동 갱신.
- profile 변경 시 Header 자동 갱신.
- 완료율 계산이 Task 상태 업데이트와 정상 연동됨.

------------------------------------------------------------

📝 리뷰 요청 사항 (Reviewer Notes)

1. 성능 검토 요청:
   TaskList가 많은 경우 LazyColumn 성능 최적화 필요 여부 확인 부탁드립니다.

2. Navigation 계약 확인:
   MainActivity에서 전달하는 onNavigateToSettings / onNavigateToGroups / onNavigateToProfile 구조가 팀 규칙(SAA + MVVM)에 적합한지 검토 바랍니다.

3. ViewModel 주입 방식(DI) 검토:
   MainScreen이 AuthViewModel + TaskViewModel 두 개를 주입받는 방식이 DI 관점에서 개선 여지가 있는지 의견 부탁드립니다.

4. 향후 기능 확장 방향:
   - Task 카테고리 아이콘 적용
   - Task 정렬 기능 추가
   - Today/Upcoming 탭 분리
   - SettingsScreen / ProfileScreen 구현 예정
