### PR TITLE
Feature/setting screen

### DIFF
--- a/app/src/main/java/com/ippo/taskflow/screen/SettingScreen.kt
+++ b/app/src/main/java/com/ippo/taskflow/screen/SettingScreen.kt
@@ -1,0 +1,265 @@
+package com.ippo.taskflow.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
+import com.ippo.taskflow.auth.AuthViewModel
+
+// 💡 MVVM 표준: ViewModel + 네비게이션 액션만 인자로 받는다.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingScreen(
+    authViewModel: AuthViewModel,
+    onNavigateToLogin: () -> Unit,
+    onNavigateBack: () -> Unit,
+    onNavigateToProfileSetting: () -> Unit,
+    onNavigateToSecurity: () -> Unit,
+    onNavigateToTheme: () -> Unit,
+    onNavigateToAbout: () -> Unit,
+    onNavigateToEtc: () -> Unit,
+) {
+    // 1. ViewModel의 상태를 관찰한다.
+    val isLoading by authViewModel.isLoading.collectAsState(initial = false)
+
+    // 2. ViewModel → 순수 UI 레이어로 브릿지
+    SettingScreenScaffold(
+        isLoading = isLoading,
+        onNavigateBack = onNavigateBack,
+        onNavigateToProfileSetting = onNavigateToProfileSetting,
+        onNavigateToSecurity = onNavigateToSecurity,
+        onNavigateToTheme = onNavigateToTheme,
+        onNavigateToAbout = onNavigateToAbout,
+        onNavigateToEtc = onNavigateToEtc,
+        onLogout = {
+            if (!isLoading) {
+                authViewModel.signOut()
+                onNavigateToLogin()
+            }
+        }
+    )
+}
+
+/**
+ * ViewModel에 의존하지 않는 순수 UI Composable
+ * 👉 Preview에서는 이걸 직접 호출한다.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SettingScreenScaffold(
+    isLoading: Boolean,
+    onNavigateBack: () -> Unit,
+    onNavigateToProfileSetting: () -> Unit,
+    onNavigateToSecurity: () -> Unit,
+    onNavigateToTheme: () -> Unit,
+    onNavigateToAbout: () -> Unit,
+    onNavigateToEtc: () -> Unit,
+    onLogout: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "설정",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "뒤로가기"
+                        )
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            TaskFlowBottomNavBar()
+        }
+    ) { innerPadding ->
+        // 실제 Setting UI
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .background(Color(0xFFF5F5F5)), // Figma 배경 느낌
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Figma 기준 카드 컨테이너
+            Surface(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                tonalElevation = 1.dp
+            ) {
+                Column {
+                    SettingMenuItem(title = "프로필설정", onClick = onNavigateToProfileSetting)
+                    Divider()
+                    SettingMenuItem(title = "개인/보안", onClick = onNavigateToSecurity)
+                    Divider()
+                    SettingMenuItem(title = "테마", onClick = onNavigateToTheme)
+                    Divider()
+                    SettingMenuItem(title = "지역", onClick = onNavigateToTheme)
+                    Divider()
+                    SettingMenuItem(title = "언어", onClick = onNavigateToTheme)
+                    Divider()
+                    SettingMenuItem(title = "알림", onClick = onNavigateToAbout)
+                    Divider()
+                    SettingMenuItem(title = "공지사항", onClick = onNavigateToAbout)
+                    Divider()
+                    SettingMenuItem(title = "이용약관", onClick = onNavigateToAbout)
+                    Divider()
+                    SettingMenuItem(title = "앱 버전", onClick = onNavigateToAbout)
+                    Divider()
+                    SettingMenuItem(title = "기타", onClick = onNavigateToEtc)
+                    Divider()
+                    // 🔴 로그아웃
+                    SettingMenuItem(
+                        title = "로그아웃",
+                        isDestructive = true,
+                        onClick = onLogout
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * 단일 설정 항목 Composable
+ * - Figma 리스트 아이템 느낌으로 패딩/폰트 맞춤
+ */
+@Composable
+private fun SettingMenuItem(
+    title: String,
+    isDestructive: Boolean = false,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontWeight = FontWeight.Medium,
+                color = if (isDestructive)
+                    MaterialTheme.colorScheme.error
+                else
+                    MaterialTheme.colorScheme.onSurface
+            ),
+            modifier = Modifier.weight(1f)
+        )
+        // ▶ 우측 화살표(Placeholder) — 나중에 아이콘 리소스로 교체 가능
+        Text(
+            text = "›",
+            style = MaterialTheme.typography.bodyLarge
+        )
+    }
+}
+
+/**
+ * DailyTaskScreen 과 동일하게 사용할 하단 네비게이션 바 (Home / Group / Profile)
+ * - 실제 네비게이션 람다는 NavHost 쪽에서 교체 예정.
+ */
+@Composable
+private fun TaskFlowBottomNavBar() {
+    Surface(
+        color = Color(0xFF9CFFC4), // Figma 하단 그린 톤과 비슷하게
+        tonalElevation = 3.dp,
+        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(64.dp)
+                .padding(horizontal = 48.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            BottomNavItem(
+                icon = Icons.Default.Home,
+                label = "Home",
+                onClick = { /* TODO: Home 이동 */ }
+            )
+            BottomNavItem(
+                icon = Icons.Default.Group,
+                label = "Group",
+                onClick = { /* TODO: Group 이동 */ }
+            )
+            BottomNavItem(
+                icon = Icons.Default.Person,
+                label = "Profile",
+                onClick = { /* TODO: Profile 이동 */ }
+            )
+        }
+    }
+}
+
+@Composable
+private fun BottomNavItem(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 6.dp, horizontal = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(imageVector = icon, contentDescription = label)
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+/**
+ * 🖼 Preview용 Composable
+ * - ViewModel 없이 순수 UI만 확인
+ */
+@Preview(showBackground = true)
+@Composable
+private fun SettingScreenPreview() {
+    MaterialTheme { // 프로젝트 테마가 있으면 여기서 감싸도 됨 (ex. TaskFlowTheme)
+        SettingScreenScaffold(
+            isLoading = false,
+            onNavigateBack = {},
+            onNavigateToProfileSetting = {},
+            onNavigateToSecurity = {},
+            onNavigateToTheme = {},
+            onNavigateToAbout = {},
+            onNavigateToEtc = {},
+            onLogout = {}
+        )
+    }
+}


### PR DESCRIPTION
📌 SettingScreen 기능 개발 – MVVM 구조 기반 UI 정리 및 네비게이션 액션 분리

✅ 개요 (Overview)

본 PR에서는 TaskFlow의 설정 페이지(SettingScreen)를 MVVM 구조에 맞게 재구성하고,
AuthViewModel과의 연동 및 모든 설정 메뉴의 Navigation Callback을 표준 규칙(SAA + MVVM)에 따라 분리했습니다.

Figma 디자인의 구조(카드 리스트, 좌측 탭 간격, 라운드 처리)를 그대로 반영하였으며,
ViewModel을 UI 레이어로 전달하지 않는 Scaffold 컴포넌트 분리 방식을 적용해 Preview/Test 환경에서도 정상적으로 렌더링되도록 설계했습니다.

✅ 개요 (Overview)

본 PR에서는 TaskFlow의 설정 페이지(SettingScreen)를 MVVM 구조에 맞게 재구성하고,
AuthViewModel과의 연동 및 모든 설정 메뉴의 Navigation Callback을 표준 규칙(SAA + MVVM)에 따라 분리했습니다.

Figma 디자인의 구조(카드 리스트, 좌측 탭 간격, 라운드 처리)를 그대로 반영하였으며,
ViewModel을 UI 레이어로 전달하지 않는 Scaffold 컴포넌트 분리 방식을 적용해 Preview/Test 환경에서도 정상적으로 렌더링되도록 설계했습니다.

2. AuthViewModel 상태(StateFlow) 연동

기능                          적용 내용
Loading State         isLoading observe → 로그아웃 처리 중복 방지
Logout Logic          authViewModel.signOut() 호출 후 onNavigateToLogin() 처리
UI 독립성                  Scaffold에서는 ViewModel 직접 접근 금지

➡️ 로그아웃·로딩 처리 흐름을 SAA 규칙에 맞게 구현.

⸻

4. Figma 기반 Setting UI 구성
	•	배경 컬러: #F5F5F5 (Figma 스타일)
	•	카드 Surface + RoundedCornerShape(16dp)
	•	Divider로 섹션 구분
	•	오른쪽 “›” UI 구성 (향후 아이콘 리소스 적용 가능)
	•	destructive item (로그아웃) → Material error 색상 적용

➡️ 시각적 구성과 UX 요소가 Figma 시안과 동일하게 구현됨.

⸻

5. 바텀 네비게이션(TaskFlowBottomNavBar) 구현
	•	Home / Group / Profile 3개 메뉴 구성
	•	현재는 onClick 내부 TODO 형태 → MainActivity에서 콜백 주입 후 연결 예정
	•	상단 라운드 처리 + Green 톤 적용하여 앱 전체 디자인 통일

➡️ 향후 재사용 가능한 공통 네비게이션 컴포넌트로 확장 가능.

⸻

🔍 테스트 사항 (Test & Verification)

✔ UI 렌더링 TestActivity 검증
	•	설정 항목 목록 정상 표시
	•	Surface/Divider/UI 색상 Figma와 동일하게 반영됨

✔ Navigation Callback 검증
	•	프로필 설정 이동
	•	개인/보안
	•	테마
	•	알림/공지/기타 메뉴
	•	로그아웃 → MainActivity로 콜백 정상 전달

✔ ViewModel 연동 검증
	•	isLoading 상태에 따라 로그아웃 중복 호출 방지
	•	signOut() → Login 화면 이동 정상 흐름

⸻

📝 리뷰 요청 사항 (Reviewer Notes)

1. Navigation 구조 적합성 검토

현재 SettingScreen은 모든 이동을 콜백 형태로 전달하고 있으며,
ViewModel은 UI 네비게이션을 직접 제어하지 않는 규칙을 유지하고 있음.
→ 이 구조가 전체 SAA 규칙과 일치하는지 검토 요청.

2. ViewModel 주입 방식

현재는 AuthViewModel 단독 주입.
DI 관점에서는 기능별로 모듈화가 잘 되어 있으나,
추후 Settings에 Task/Group 설정이 추가될 경우 DI 확장 필요.

3. UI 구조 및 재사용성
	•	SettingMenuItem, BottomNav 등 재사용성을 고려한 모듈화가 적절한지 확인 부탁드립니다.
	•	공통 바텀바를 별도로 컴포넌트 패키지로 분리하는 방안 제안.

4. 향후 기능 확장 방향
	•	세부 설정 화면(ProfileSetting / SecuritySetting / ThemeSetting) 구현 예정
	•	우측 아이콘 → Figma 리소스로 교체
	•	지역/언어 메뉴 실제 기능 구현
	•	BottomNav에 실제 NavigationController 연동

