### PR TITLE
feat: GroupTaskScreen.kt

### DIFF
--- a/app/src/main/java/com/ippo/taskflow/screen/GroupTaskScreen.kt
+++ b/app/src/main/java/com/ippo/taskflow/screen/GroupTaskScreen.kt
@@ -1,0 +1,393 @@
+package com.ippo.taskflow.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ippo.taskflow.data.Group
+import com.ippo.taskflow.group.GroupViewModel
+
+// 메인 색상 (MainScreen과 통일)
+private val TaskFlowGreen = Color(0xFF1E8A3B)
+private val TaskFlowLightGreen = Color(0xFFE0FFE8)
+
+@Composable
+fun GroupTaskScreen(
+    groupViewModel: GroupViewModel,
+    onNavigateToMain: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+    onNavigateToAddGroup: () -> Unit,
+    onNavigateToGroupDetail: (groupId: String) -> Unit,
+) {
+    // ViewModel State Observe
+    val groupList by groupViewModel.groupList.collectAsState()
+    val isLoading by groupViewModel.isLoading.collectAsState()
+    val errorMessage by groupViewModel.error.collectAsState()
+
+    // 첫 진입 시 그룹 목록 로드
+    LaunchedEffect(Unit) {
+        groupViewModel.loadGroups()
+    }
+
+    Scaffold(
+        bottomBar = {
+            GroupBottomNavBar(
+                onHomeClick = onNavigateToMain,
+                onGroupsClick = { /* 현재 화면 → No-op */ },
+                onProfileClick = onNavigateToProfile
+            )
+        }
+    ) { innerPadding ->
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                // 상단바
+                GroupTopBar(
+                    onBackClick = onNavigateToMain // 상단 뒤로가기 → 메인으로
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // "내 그룹" 헤더 + 새 그룹 텍스트 버튼
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "내 그룹",
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 18.sp
+                        )
+                    )
+                    Text(
+                        text = "+ 새 그룹",
+                        color = TaskFlowGreen,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 14.sp,
+                        modifier = Modifier.clickable { onNavigateToAddGroup() }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // 에러 표시
+                if (!errorMessage.isNullOrBlank()) {
+                    Text(
+                        text = errorMessage!!,
+                        color = Color.Red,
+                        fontSize = 12.sp
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+
+                // 그룹 목록 + "새로운 그룹 만들기" 카드
+                GroupListSection(
+                    groups = groupList,
+                    isLoading = isLoading,
+                    onGroupClick = { groupId ->
+                        onNavigateToGroupDetail(groupId)
+                    },
+                    onAddGroupClick = onNavigateToAddGroup
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupTopBar(
+    onBackClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "뒤로가기"
+            )
+        }
+        Text(
+            text = "TaskFlow",
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Bold
+            )
+        )
+    }
+}
+
+@Composable
+private fun GroupListSection(
+    groups: List<Group>,
+    isLoading: Boolean,
+    onGroupClick: (String) -> Unit,
+    onAddGroupClick: () -> Unit,
+) {
+    if (isLoading) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "그룹 목록을 불러오는 중...", color = Color.Gray)
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(bottom = 96.dp)
+    ) {
+        items(groups, key = { it.groupId }) { group ->
+            GroupCard(
+                group = group,
+                onClick = { onGroupClick(group.groupId) }
+            )
+        }
+
+        // 하단 "새로운 그룹 만들기" 카드
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+            AddGroupCard(
+                onClick = onAddGroupClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun GroupCard(
+    group: Group,
+    onClick: () -> Unit,
+) {
+    // 🔸 현재는 Task 통계 계산 로직이 ViewModel에 없으므로 placeholder 값 사용
+    val memberCount = group.memberUids.size
+    val inProgressCount = 0        // TODO: ViewModel에서 실제 진행 Task 개수 연동
+    val completionRatio = 0f       // TODO: ViewModel에서 완료율(0f~1f) 연동
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp)
+        ) {
+            // 상단: 그룹 이름 + 멤버 수
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = group.name.ifBlank { "이름 없는 그룹" },
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontWeight = FontWeight.Bold
+                    ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Group,
+                        contentDescription = "멤버 수",
+                        tint = Color.Gray,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = memberCount.toString(),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // 중간: 진행 Task 정보 (placeholder)
+            Text(
+                text = "${inProgressCount}개 진행 중",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.Gray
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            // 진행률 바
+            LinearProgressIndicator(
+                progress = completionRatio,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(6.dp)
+                    .clip(RoundedCornerShape(50)),
+                color = TaskFlowGreen,
+                trackColor = Color(0xFFE5E5E5)
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            // 완료율 텍스트 (오른쪽 정렬 느낌)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                Text(
+                    text = "${(completionRatio * 100).toInt()}%",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddGroupCard(
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp)
+            .clickable { onClick() },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = Color.White
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(TaskFlowLightGreen),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "+",
+                        color = TaskFlowGreen,
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "새로운 그룹 만들기",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = Color(0xFF7A7A7A)
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupBottomNavBar(
+    onHomeClick: () -> Unit,
+    onGroupsClick: () -> Unit,
+    onProfileClick: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 8.dp,
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(TaskFlowLightGreen)
+                .padding(horizontal = 40.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onHomeClick) {
+                Icon(
+                    imageVector = Icons.Filled.Home,
+                    contentDescription = "Home",
+                    tint = Color.Black
+                )
+            }
+            IconButton(onClick = onGroupsClick) {
+                Icon(
+                    imageVector = Icons.Filled.Group,
+                    contentDescription = "Groups",
+                    tint = TaskFlowGreen // 현재 선택된 탭
+                )
+            }
+            IconButton(onClick = onProfileClick) {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = "Profile",
+                    tint = Color.Black
+                )
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
📌 GroupTaskScreen 기능 개발 – 그룹 대시보드 UI & MVVM 연동 (※ 그룹 통계는 부분 구현 상태)

---

### ✅ 개요 (Overview)

이번 PR에서는 **현재 로그인된 사용자가 속한 그룹들을 한눈에 볼 수 있는 GroupTaskScreen**을 구현했습니다.
Figma에 맞춰 그룹 카드 형태의 대시보드를 구성하고, `GroupViewModel`로부터 그룹 목록을 받아 표시하도록 MVVM 구조에 맞게 View와 로직을 분리했습니다.

아직 **그룹별 Task 지표(진행 개수, 완료율)는 ViewModel 로직과 완전히 연결되지 않은 상태**이며, UI 구조를 먼저 완성해둔 뒤 추후 `TaskViewModel` 협력 로직을 추가하는 방향으로 설계되어 있습니다.

---

### 🔧 주요 변경 사항 (Key Changes)

#### 1. GroupTaskScreen Composable 구조 구현

* **Composable:** `GroupTaskScreen`
* **패키지:** `com.ippo.taskflow.screen`
* **프로퍼티 계약:**

  * `groupViewModel: GroupViewModel`
  * `onNavigateToMain: () -> Unit`
  * `onNavigateToProfile: () -> Unit`
  * `onNavigateToAddGroup: () -> Unit`
  * `onNavigateToGroupDetail: (groupId: String) -> Unit`

구성 요소는 다음과 같이 모듈화했습니다.

* 상단 타이틀 / 헤더 영역
* 그룹 요약 문구(“그룹 목록”, 서브텍스트 등)
* 그룹 카드 리스트(LazyColumn)
* 하단 “새로운 그룹 만들기” 버튼
* 하단 네비게이션 바(Home / Group / Profile)

View는 **NavController에 직접 접근하지 않고**, 상위에서 넘겨주는 콜백(onNavigateTo…)만 호출하도록 설계하여 SAA + MVVM 규칙을 지켰습니다.

---

#### 2. GroupViewModel StateFlow 기반 그룹 목록 렌더링

* `groupViewModel.groupList: StateFlow<List<Group>>`
* `groupViewModel.isLoading: StateFlow<Boolean>`
* `groupViewModel.error: StateFlow<String?>`

위 상태를 `collectAsState()`로 Observe 하여:

* 로딩 중: “로딩 중…” 표시
* 에러 발생: 에러 메시지 텍스트 표시
* 데이터 있음: **그룹 카드 리스트**로 렌더링

각 그룹 카드는 다음 정보를 표시합니다.

* 그룹 이름 (`group.name`)
* 멤버 수 (`group.memberUids.size`)
* 진행 Task 개수 / 완료율 (현재는 placeholder 값, 아래 ⚠ 참고)
* “자세히 보기” 또는 카드 전체 클릭 시 → `onNavigateToGroupDetail(group.groupId)` 호출

---

#### 3. Figma 레이아웃 반영 및 공통 디자인 유지

* 전체 배경, 카드 라운드, 패딩, 타이포그래피를 기존 MainScreen / AddGroupScreen과 통일되도록 구성.
* TaskFlow 메인 컬러(`TaskFlowGreen`, `TaskFlowLightGreen`)를 재사용하여 브랜드 일관성 유지.
* 하단 네비게이션 바:

  * Home / Group / Profile 세 개의 아이콘 버튼
  * **현재 화면이 Group 탭이므로 Group 아이콘에만 초록색 포커스 색상 적용**

---

### ⚠ 아직 명세서랑 100% 일치 안 하는 부분

#### 1. 그룹 통계(진행 Task 개수, 완료율)

명세서에는 그룹 통계가 이렇게 정의되어 있었음:

> Group Model + `groupViewModel.calculateGroupMetrics(groupId)` (State)

즉,

* 각 그룹별 Task 목록을 기준으로
* 진행 중 Task 개수, 완료 Task 개수, 완료율(%) 등을 계산해서
* `GroupTaskScreen`은 그 **계산된 상태**만 받아서 UI에 그리는 구조.

현재 구현은 아래와 같은 placeholder 상태입니다:

```kotlin
val memberCount = group.memberUids.size
val inProgressCount = 0        // TODO: 실제 Task 데이터와 연동 필요
val completionRatio = 0f       // TODO: 실제 완료율 계산 필요
```

* `TaskViewModel`과 협력해서 `groupId` 기준으로 Task들을 모으고,
* 그 결과를 기반으로 **진행 개수 / 완료율을 계산하는 로직**은
  아직 `GroupViewModel` / `TaskViewModel` 쪽에 정의되어 있지 않습니다.
* 따라서 현재 GroupTaskScreen의 UI 구조는 완성되어 있지만,
  **표시되는 통계 값은 실제 Firestore Task 데이터 기반이 아니라 “빈 자리(더미 값)” 상태**입니다.

이건 View 쪽의 문제라기보다는,
아직 `calculateGroupMetrics` 같은 ViewModel 단의 상태/함수가 만들어지지 않아서 발생한 설계 상의 “미완성 부분”입니다.

---

### 🔍 향후 개선 방향 (그룹별 Task 통계 설계 제안)

아키텍처를 깨지 않으면서 그룹 통계를 완성하기 위한 제안입니다.

#### 1. GroupMetrics 데이터 클래스 정의

```kotlin
data class GroupTaskMetrics(
    val totalTasks: Int,
    val completedTasks: Int,
) {
    val completionRate: Int
        get() = if (totalTasks == 0) 0
                else (completedTasks * 100f / totalTasks).toInt()
}
```

#### 2. GroupViewModel에 그룹별 통계 StateFlow 추가

```kotlin
class GroupViewModel(
    private val authViewModel: AuthViewModel,
    private val taskViewModel: TaskViewModel
) : ViewModel() {

    private val _groupMetrics =
        MutableStateFlow<Map<String, GroupTaskMetrics>>(emptyMap())
    val groupMetrics: StateFlow<Map<String, GroupTaskMetrics>> = _groupMetrics

    fun refreshGroupMetrics() {
        val currentGroups = _groupList.value

        // 각 groupId마다 TaskViewModel와 협력해서 통계 계산
        currentGroups.forEach { group ->
            taskViewModel.loadGroupTaskMetrics(group.groupId) { metrics ->
                _groupMetrics.value = _groupMetrics.value.toMutableMap().apply {
                    this[group.groupId] = metrics
                }
            }
        }
    }
}
```

`loadGroups()`가 완료된 시점, 또는 그룹/Task가 변경된 시점에
`refreshGroupMetrics()`를 호출하는 방식으로 동기화할 수 있습니다.

#### 3. TaskViewModel에 그룹별 Task 통계 계산 함수 추가

```kotlin
fun loadGroupTaskMetrics(
    groupId: String,
    onResult: (GroupTaskMetrics) -> Unit
) {
    db.collection("tasks")
        .whereEqualTo("groupId", groupId)
        .get()
        .addOnSuccessListener { snapshot ->
            val tasks = snapshot.toObjects(Task::class.java)
            val total = tasks.size
            val done = tasks.count { it.status.equals("DONE", ignoreCase = true) }
            onResult(GroupTaskMetrics(totalTasks = total, completedTasks = done))
        }
        .addOnFailureListener {
            onResult(GroupTaskMetrics(totalTasks = 0, completedTasks = 0))
        }
}
```

#### 4. GroupTaskScreen에서 실제 metrics와 연결

```kotlin
val metricsMap by groupViewModel.groupMetrics.collectAsState()

// 각 그룹 카드 내부:
val metrics = metricsMap[group.groupId]
val inProgressCount = (metrics?.totalTasks ?: 0) - (metrics?.completedTasks ?: 0)
val completionRatio = metrics?.completionRate ?: 0
```

이렇게 되면:

* View는 **더 이상 0, 0f 같은 더미 값에 의존하지 않고**,
* `GroupViewModel.groupMetrics`에 실린 실제 통계 상태만 사용하게 되고,
* 명세서에 적힌 “Group Model + ViewModel metrics State” 구조와 100% 일치하게 됩니다.

---

### 📝 리뷰 요청 사항 (Reviewer Notes)

1. **현재 상태에 대한 인지 공유**

   * GroupTaskScreen의 UI·네비게이션·ViewModel 연동은 명세서/피그마 기준으로 거의 완성된 상태입니다.
   * 다만 **그룹별 Task 통계(진행 개수, 완료율)는 아직 placeholder 값**이며, 추후 ViewModel 단 로직을 추가해야 완전해집니다.

2. **GroupMetrics 설계 방향 검토 요청**

   * `GroupViewModel.groupMetrics: StateFlow<Map<String, GroupTaskMetrics>>` 형태로 설계하는 방향이 괜찮을지,
   * 혹은 TaskViewModel가 통계를 직접 노출하고 GroupViewModel은 그걸 단순 위임만 하는 것이 더 나을지 의견 부탁드립니다.

3. **TaskViewModel 협력 방식**

   * 제안한 `loadGroupTaskMetrics(groupId, onResult)` 콜백 방식이 팀의 비동기 처리 스타일과 잘 맞는지,
   * Flow 기반으로 통계 스트림을 노출하는 편이 더 좋을지 논의가 필요합니다.

4. **성능 및 쿼리 부담**

   * 그룹 수가 많아질 경우, 각 groupId마다 별도 Task 쿼리를 날리는 방식이 비효율적일 수 있습니다.
   * 향후에는 “현재 사용자의 모든 Task를 한 번에 로드 → 메모리에서 groupId별로 집계”하는 방식도 고려할 수 있을지 검토 부탁드립니다.
