### PR TITLE
feat: AddGroupScreen.kt

### DIFF
--- a/app/src/main/java/com/ippo/taskflow/screen/AddGroupScreen.kt
+++ b/app/src/main/java/com/ippo/taskflow/screen/AddGroupScreen.kt
@@ -1,0 +1,387 @@
+package com.ippo.taskflow.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ippo.taskflow.auth.AuthViewModel
+import com.ippo.taskflow.group.GroupViewModel
+
+// 메인 색상 (다른 화면과 통일)
+private val TaskFlowGreen = Color(0xFF1E8A3B)
+private val TaskFlowLightGreen = Color(0xFFE0FFE8)
+
+@Composable
+fun AddGroupScreen(
+    groupViewModel: GroupViewModel,
+    authViewModel: AuthViewModel,
+    onGroupAdded: () -> Unit,
+    onNavigateBack: () -> Unit,
+    onNavigateToMain: () -> Unit,
+    onNavigateToGroups: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+) {
+    // UI 상태 (이름/설명/이메일 입력값 등)는 ViewModel 말고 화면 로컬 상태로 관리
+    var groupName by rememberSaveable { mutableStateOf("") }
+    var groupDescription by rememberSaveable { mutableStateOf("") }
+
+    var inviteEmail by rememberSaveable { mutableStateOf("") }
+    var invitedEmails by rememberSaveable { mutableStateOf(listOf<String>()) }
+    var emailError by rememberSaveable { mutableStateOf<String?>(null) }
+
+    val isLoading by groupViewModel.isLoading.collectAsState()
+    val groupError by groupViewModel.error.collectAsState()
+
+    val isCreateEnabled = groupName.isNotBlank() // 생성자 본인은 자동 멤버이므로 이것만 체크
+
+    Scaffold(
+        bottomBar = {
+            AddGroupBottomNavBar(
+                onHomeClick = onNavigateToMain,
+                onGroupsClick = onNavigateToGroups,
+                onProfileClick = onNavigateToProfile
+            )
+        }
+    ) { innerPadding ->
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                // 상단바
+                AddGroupTopBar(onBackClick = onNavigateBack)
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "새로운 Group 추가하기",
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Group 이름 필드
+                Text(
+                    text = "Group 이름",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                TaskFlowInputBox(
+                    value = groupName,
+                    onValueChange = { groupName = it },
+                    placeholder = "Task 이름을 입력하세요.",
+                    singleLine = true,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Group 설명 필드
+                Text(
+                    text = "설명",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                TaskFlowInputBox(
+                    value = groupDescription,
+                    onValueChange = { groupDescription = it },
+                    placeholder = "Group 설명을 입력하세요.",
+                    singleLine = false,
+                    minHeight = 100.dp
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 멤버 이메일 추가 영역 (UI + authViewModel.getUidByEmail 활용)
+                Text(
+                    text = "멤버 이메일로 초대",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TaskFlowInputBox(
+                        value = inviteEmail,
+                        onValueChange = {
+                            inviteEmail = it
+                            emailError = null
+                        },
+                        placeholder = "이메일을 입력하세요.",
+                        singleLine = true,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Button(
+                        onClick = {
+                            val email = inviteEmail.trim()
+                            if (email.isBlank()) return@Button
+
+                            // 이메일로 UID 검색 → 성공하면 invitedEmails 목록에 추가
+                            authViewModel.getUidByEmail(email) { uid ->
+                                if (uid != null) {
+                                    // 이미 추가된 이메일이면 중복 추가 방지
+                                    if (!invitedEmails.contains(email)) {
+                                        invitedEmails = invitedEmails + email
+                                    }
+                                    inviteEmail = ""
+                                    emailError = null
+                                } else {
+                                    emailError = "해당 이메일의 사용자를 찾을 수 없습니다."
+                                }
+                            }
+                        },
+                        enabled = inviteEmail.isNotBlank(),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = TaskFlowGreen,
+                            disabledContainerColor = TaskFlowGreen.copy(alpha = 0.4f)
+                        )
+                    ) {
+                        Text(text = "추가", color = Color.White)
+                    }
+                }
+
+                if (emailError != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = emailError!!,
+                        color = Color.Red,
+                        fontSize = 11.sp
+                    )
+                }
+
+                if (invitedEmails.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "추가된 멤버 (${invitedEmails.size})",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Group 생성 에러 메시지
+                if (!groupError.isNullOrBlank()) {
+                    Text(
+                        text = groupError!!,
+                        color = Color.Red,
+                        fontSize = 12.sp
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+
+                // 하단 여백 밀어내기
+                Spacer(modifier = Modifier.weight(1f))
+
+                // Group 추가 버튼
+                Button(
+                    onClick = {
+                        // 현재 GroupViewModel.createGroup(name, description)은
+                        // 생성자 본인만 멤버로 추가하므로, 초대한 이메일들은
+                        // 추후 GroupDetailScreen 등에서 inviteMemberByEmail로 처리 예정.
+                        groupViewModel.createGroup(
+                            name = groupName,
+                            description = groupDescription
+                        )
+
+                        // 현재 구조상 성공 콜백이 없어서, 우선 즉시 돌아가게 처리
+                        onGroupAdded()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    enabled = isCreateEnabled && !isLoading,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = TaskFlowGreen,
+                        disabledContainerColor = TaskFlowGreen.copy(alpha = 0.4f)
+                    ),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    if (isLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(22.dp),
+                            color = Color.White,
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text(
+                            text = "Group 추가",
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+/**
+ * Figma 스타일에 맞춘 공통 입력 박스 컴포넌트
+ * - BasicTextField 기반
+ * - 배경 연회색, 라운드, 포커스 시 스타일 변화 없음
+ * - placeholder 직접 구현
+ */
+@Composable
+private fun TaskFlowInputBox(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    singleLine: Boolean,
+    modifier: Modifier = Modifier,
+    minHeight: Dp = 0.dp,
+    textStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(
+        color = Color.Black,
+        fontSize = 14.sp
+    ),
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = singleLine,
+        textStyle = textStyle,
+        modifier = modifier
+            .fillMaxWidth(),
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .background(Color(0xFFF7F7F7), RoundedCornerShape(10.dp))
+                    .then(
+                        if (minHeight > 0.dp) Modifier.heightIn(min = minHeight)
+                        else Modifier
+                    )
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                contentAlignment = Alignment.TopStart
+            ) {
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        style = textStyle.copy(
+                            color = Color.Gray
+                        )
+                    )
+                }
+                innerTextField()
+            }
+        }
+    )
+}
+
+@Composable
+private fun AddGroupTopBar(
+    onBackClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "뒤로가기"
+            )
+        }
+        Text(
+            text = "TaskFlow",
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontWeight = FontWeight.Bold
+            )
+        )
+    }
+}
+
+@Composable
+private fun AddGroupBottomNavBar(
+    onHomeClick: () -> Unit,
+    onGroupsClick: () -> Unit,
+    onProfileClick: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 8.dp,
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(TaskFlowLightGreen)
+                .padding(horizontal = 40.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onHomeClick) {
+                Icon(
+                    imageVector = Icons.Filled.Home,
+                    contentDescription = "Home",
+                    tint = Color.Black
+                )
+            }
+            IconButton(onClick = onGroupsClick) {
+                Icon(
+                    imageVector = Icons.Filled.Group,
+                    contentDescription = "Groups",
+                    tint = TaskFlowGreen   // Group 탭 강조
+                )
+            }
+            IconButton(onClick = onProfileClick) {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = "Profile",
+                    tint = Color.Black
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
📌 AddGroupScreen 기능 개발 – 새 그룹 생성 UI & 이메일 초대 흐름 구현 (MVVM 기반)

---

### ✅ 개요 (Overview)

이번 PR에서는 **새로운 그룹을 생성하는 AddGroupScreen**을 구현하고,
`GroupViewModel` / `AuthViewModel`과 연동하여 **그룹 생성 + 이메일 기반 멤버 초대 UI 흐름**을 구축했습니다.

UI는 Figma 시안을 최대한 반영했으며,
입력 필드/버튼/네비게이션 구조는 모두 **MVVM 규칙(SAA + View는 상태 관찰 + 콜백만 호출)**을 지키도록 설계했습니다.

---

### 🔧 주요 변경 사항 (Key Changes)

#### 1. AddGroupScreen Composable 구현

* **Composable:** `AddGroupScreen`

* **패키지:** `com.ippo.taskflow.screen`

* **파라미터 계약:**

  * `groupViewModel: GroupViewModel` – 그룹 생성/로딩/에러 상태 관리
  * `authViewModel: AuthViewModel` – 이메일 기반 UID 검색
  * `onGroupAdded: () -> Unit` – 그룹 생성 완료 후 이전 화면 복귀
  * `onNavigateBack: () -> Unit` – 상단 뒤로가기
  * `onNavigateToMain / onNavigateToGroups / onNavigateToProfile` – 하단 네비게이션 콜백

* **로컬 UI 상태 (rememberSaveable):**

  * `groupName`: 그룹 이름
  * `groupDescription`: 그룹 설명
  * `inviteEmail`: 초대할 이메일 입력값
  * `invitedEmails: List<String>`: 초대에 성공한 이메일 목록(표시용)
  * `emailError: String?`: 이메일 초대 실패 메시지

* **ViewModel 상태 관찰:**

  * `groupViewModel.isLoading` → “Group 추가” 버튼 로딩 및 disabled 처리
  * `groupViewModel.error` → 화면 하단 에러 메시지 표시

* **버튼 활성화 조건:**

  * `groupName.isNotBlank()` 일 때만 “Group 추가” 버튼 활성화
    (멤버는 생성자 본인이 기본 포함되므로, 이름만 필수로 체크)

---

#### 2. BasicTextField 기반 공통 입력 컴포넌트 도입

* **컴포넌트:** `TaskFlowInputBox`

  * `BasicTextField + decorationBox`로 구현
  * 연회색 배경(`0xFFF7F7F7`) + 라운드 모서리 + 내부 패딩 구성
  * `placeholder`를 직접 렌더링해서 **Figma와 유사한 커스텀 인풋 박스** 구현
  * `singleLine` / `minHeight` 로 단일 입력(이름)과 멀티라인 입력(설명) 모두 지원
  * 포커스 여부에 따라 테두리/색상 변화 없음 → 시안과 동일한 플랫 스타일 유지

> ✅ 기존 TextField 버전보다 **디자인 커스터마이즈에 유리한 BasicTextField 버전**으로 최종 선택

---

#### 3. 이메일 기반 멤버 초대 UI + AuthViewModel 연동

AddGroupScreen의 핵심 UX 중 하나인 **“멤버 이메일로 초대”** 영역을 구현했습니다.

* UI 구성:

  * 왼쪽: 이메일 입력 인풋 (`TaskFlowInputBox`)
  * 오른쪽: “추가” 버튼

* 동작 흐름:

  ```kotlin
  authViewModel.getUidByEmail(email) { uid ->
      if (uid != null) {
          if (!invitedEmails.contains(email)) {
              invitedEmails = invitedEmails + email
          }
          inviteEmail = ""
          emailError = null
      } else {
          emailError = "해당 이메일의 사용자를 찾을 수 없습니다."
      }
  }
  ```

  1. 사용자가 이메일 입력 후 “추가” 버튼 클릭
  2. `AuthViewModel.getUidByEmail(email)` 호출 → Firestore `users` 컬렉션에서 해당 이메일의 UID 검색
  3. UID가 존재하면:

     * `invitedEmails` 리스트에 **이메일 주소만 추가** (중복 방지)
     * 입력값 초기화, 오류 메시지 제거
  4. UID가 없으면:

     * `emailError`에 실패 메시지 저장 → 화면에 빨간 글씨로 노출

* invitedEmails의 현재 역할:

  * **UI 표시용 로컬 상태** (ex. "추가된 멤버 (n명)")
  * 아직 Firestore의 `memberUids`에는 반영하지 않음

> ⚠️ 현재 단계에서는 **초대된 이메일 목록이 Firestore에 저장되지 않고**,
> **그룹 생성 시점에는 생성자 본인만 멤버**로 포함됩니다. (아래에 상세 설명)

---

#### 4. 그룹 생성 로직과 초대 이메일의 관계 (현재 설계 상태)

현재 `GroupViewModel.createGroup(name, description)` 의 구현은:

* `ownerId = currentUserId`
* `memberUids = listOf(currentUserId)`
  → **생성자 본인만 멤버로 포함**하는 구조입니다.

AddGroupScreen에서는:

* UI에서 이메일 입력 → `getUidByEmail` 호출
* UID가 존재하면 **`invitedEmails` 리스트에 이메일 문자열만 저장 (UI 표시 전용)**
* “Group 추가” 버튼 클릭 시:

  ```kotlin
  groupViewModel.createGroup(
      name = groupName,
      description = groupDescription
  )
  onGroupAdded()
  ```

즉, **현재 PR에서 그룹 생성 시점에는 `invitedEmails`를 실제 멤버로 넘기지 않고**,
기존 로직대로 “생성자만 멤버”인 그룹을 만든 뒤,

> 초대된 이메일은 추후 `GroupDetailScreen` 등에서
> `groupViewModel.inviteMemberByEmail(groupId, email)`
> 을 사용해 실제 멤버로 추가하는 흐름을 전제로 설계했습니다.

📌 요약하면:

* UI는 **이메일 기반 초대 플로우 전체를 미리 그려둔 상태**이고,
* 실제 Firestore `memberUids` 업데이트는 **추후 GroupDetailScreen에서 처리**할 수 있도록 여지를 남긴 구조입니다.
* 이 PR은 **“그룹 생성 + 초대 후보 표시까지”를 담당하고,
  “초대 반영(멤버로 추가)”은 다음 단계로 넘기는** 역할을 합니다.

---

#### 5. 상단/하단 네비게이션 UI

* **상단바 (`AddGroupTopBar`)**

  * 좌측 ArrowBack 아이콘 → `onBackClick()` 호출
  * 타이틀: “TaskFlow”

* **하단 네비게이션 바 (`AddGroupBottomNavBar`)**

  * Home / Groups / Profile 아이콘 버튼
  * 현재 화면이 Group 관련이므로:

    * Group 아이콘만 `TaskFlowGreen` 색상으로 강조
    * Home / Profile은 기본 검은색

네비게이션은 모두 상위에서 주입된 콜백을 호출하며,
View는 NavController를 직접 모르는 구조를 유지했습니다.

---

### 🔍 테스트 사항 (Test & Verification)

✔ **UI 동작 확인**

* Group 이름/설명 입력 시 값이 정상적으로 로컬 상태에 반영되는지 확인
* 이메일 입력 후 “추가” 버튼 클릭 시:

  * 정상 이메일 → `invitedEmails`에 추가 & 입력창 초기화
  * 존재하지 않는 이메일 → 에러 메시지 노출
* “Group 추가” 버튼:

  * groupName이 비어 있을 때 disabled
  * 로딩 중(isLoading=true)일 때 인디케이터 표시 및 버튼 비활성화

✔ **ViewModel 연동 검증**

* `groupViewModel.isLoading` 변경 시 버튼 상태/인디케이터가 정상적으로 변경되는지 확인
* `groupViewModel.error` 발생 시 하단 에러 텍스트가 잘 나타나는지 확인
* `AuthViewModel.getUidByEmail`과의 연동이 정상적으로 UID 존재/미존재를 구분하는지 확인

✔ **네비게이션 콜백 확인**

* 뒤로가기 버튼 → `onNavigateBack()`이 올바르게 호출되는지
* 하단 Home / Groups / Profile → 각 콜백이 정상적으로 실행되는지 (NavHost 단에서 라우트 이동 확인)

---

### 📝 리뷰 요청 사항 (Reviewer Notes)

1. **이메일 초대 흐름 분리 설계에 대한 의견**

   * 현재는 **AddGroupScreen에서 “초대 후보(UI)”까지만 처리**하고,
     실제 Firestore `memberUids` 업데이트는 향후 `GroupDetailScreen`에서
     `inviteMemberByEmail(groupId, email)`를 통해 처리하는 구조입니다.
   * 그룹 생성 시점에 `invitedEmails`까지 함께 반영해야 하는지,
     아니면 지금처럼 “그룹 생성 → 이후 상세 화면에서 초대 처리” 플로우가 더 자연스러운지 의견 부탁드립니다.

2. **GroupViewModel 시그니처 확장 여부**

   * 차후에 `createGroup(name, description, invitedEmails)` 형태로 확장해서
     생성 시점에 멤버까지 같이 넣을지,
   * 혹은 `createGroup`은 현재처럼 단순 생성 책임만 두고,
     멤버 초대는 전적으로 `inviteMemberByEmail` 쪽에서만 관리하는 게 더 낫다고 보시는지 검토 부탁드립니다.

3. **BasicTextField 기반 인풋 컴포넌트 선택에 대한 피드백**

   * Material3 `TextField` 대신 `BasicTextField + decorationBox`를 사용해서
     Figma 스타일을 거의 그대로 재현한 상태입니다.
   * 이 방식이 팀 전체 UI 컴포넌트 전략(일관성/재사용성)과 잘 맞는지,
     아니면 공통 TextField 스타일을 정해서 Material3 컴포넌트를 통일 사용하는 쪽이 나을지 의견 부탁드립니다.

4. **로딩/에러 처리 확장**

   * 현재는 `createGroup` 성공/실패를 콜백으로 직접 감지하지 않고,
     버튼 클릭 직후 `onGroupAdded()`를 호출하는 단순 구조입니다.
   * 향후에는 `isLoading` 및 성공 플래그를 관찰해서
     **실제 성공이 확인된 후에만 화면을 닫는 구조**로 변경하는 것이 좋을지 검토 부탁드립니다.
