### PR TITLE
feat: AddTaskScreen.kt

### DIFF
--- a/app/src/main/java/com/ippo/taskflow/screen/AddTaskScreen.kt
+++ b/app/src/main/java/com/ippo/taskflow/screen/AddTaskScreen.kt
@@ -1,0 +1,440 @@
+package com.ippo.taskflow.screen
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccessTime
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ippo.taskflow.group.GroupViewModel
+import com.ippo.taskflow.task.TaskViewModel
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+// 공통 색상 (다른 화면과 통일)
+private val TaskFlowGreen = Color(0xFF1E8A3B)
+private val TaskFlowLightGreen = Color(0xFFE0FFE8)
+private val InputBackground = Color(0xFFF7F7F7)
+
+@Composable
+fun AddTaskScreen(
+    taskViewModel: TaskViewModel,
+    groupViewModel: GroupViewModel,
+    onTaskCreated: () -> Unit,
+    onNavigateBack: () -> Unit,
+) {
+    // ---- ViewModel state observe ----
+    val groupList by groupViewModel.groupList.collectAsState()
+    val isGroupLoading by groupViewModel.isLoading.collectAsState()
+    val groupError by groupViewModel.error.collectAsState()
+
+    val isTaskLoading by taskViewModel.isLoading.collectAsState()
+    val taskError by taskViewModel.error.collectAsState()
+
+    // ---- Local UI state ----
+    var taskName by rememberSaveable { mutableStateOf("") }
+    var taskDescription by rememberSaveable { mutableStateOf("") }
+
+    val calendar = rememberSaveable { Calendar.getInstance() }
+    var selectedDateText by rememberSaveable { mutableStateOf("") }
+    var selectedTimeText by rememberSaveable { mutableStateOf("") }
+    var dueDate: Date? by rememberSaveable { mutableStateOf<Date?>(null) }
+
+    var selectedGroupId by rememberSaveable { mutableStateOf<String?>(null) }
+    var selectedGroupName by rememberSaveable { mutableStateOf("Task 그룹을 선택하세요") }
+    var isGroupDropdownExpanded by rememberSaveable { mutableStateOf(false) }
+
+    val context = LocalContext.current
+
+    // 화면 진입 시 그룹 목록 로드
+    LaunchedEffect(Unit) {
+        groupViewModel.loadGroups()
+    }
+
+    val isCreateEnabled = taskName.isNotBlank() && selectedGroupId != null
+
+    Scaffold { innerPadding ->
+        Surface(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                // 상단 바
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "뒤로가기"
+                        )
+                    }
+                    Text(
+                        text = "새로운 Task 추가하기",
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 18.sp
+                        )
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Task 이름
+                Text(
+                    text = "Task 이름",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                TaskFlowInputBox(
+                    value = taskName,
+                    onValueChange = { taskName = it },
+                    placeholder = "Task 이름을 입력하세요.",
+                    singleLine = true
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Task 설명
+                Text(
+                    text = "설명",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                TaskFlowInputBox(
+                    value = taskDescription,
+                    onValueChange = { taskDescription = it },
+                    placeholder = "Task 설명을 입력하세요.",
+                    singleLine = false,
+                    minHeight = 100.dp
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 날짜 / 시간
+                Text(
+                    text = "날짜 / 시간",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    // 날짜 선택
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(InputBackground)
+                            .clickable {
+                                val year = calendar.get(Calendar.YEAR)
+                                val month = calendar.get(Calendar.MONTH)
+                                val day = calendar.get(Calendar.DAY_OF_MONTH)
+
+                                DatePickerDialog(
+                                    context,
+                                    { _, y, m, d ->
+                                        calendar.set(Calendar.YEAR, y)
+                                        calendar.set(Calendar.MONTH, m)
+                                        calendar.set(Calendar.DAY_OF_MONTH, d)
+                                        dueDate = calendar.time
+                                        selectedDateText = SimpleDateFormat(
+                                            "yyyy.MM.dd",
+                                            Locale.getDefault()
+                                        ).format(calendar.time)
+                                    },
+                                    year, month, day
+                                ).show()
+                            }
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = if (selectedDateText.isNotEmpty())
+                                    selectedDateText else "날짜",
+                                color = if (selectedDateText.isNotEmpty())
+                                    Color.Black else Color.Gray,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Icon(
+                                imageVector = Icons.Default.CalendarToday,
+                                contentDescription = "날짜 선택",
+                                tint = Color.Gray
+                            )
+                        }
+                    }
+
+                    // 시간 선택
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(InputBackground)
+                            .clickable {
+                                val hour = calendar.get(Calendar.HOUR_OF_DAY)
+                                val minute = calendar.get(Calendar.MINUTE)
+
+                                TimePickerDialog(
+                                    context,
+                                    { _, h, m ->
+                                        calendar.set(Calendar.HOUR_OF_DAY, h)
+                                        calendar.set(Calendar.MINUTE, m)
+                                        dueDate = calendar.time
+                                        selectedTimeText = SimpleDateFormat(
+                                            "HH:mm",
+                                            Locale.getDefault()
+                                        ).format(calendar.time)
+                                    },
+                                    hour, minute, true
+                                ).show()
+                            }
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = if (selectedTimeText.isNotEmpty())
+                                    selectedTimeText else "시간",
+                                color = if (selectedTimeText.isNotEmpty())
+                                    Color.Black else Color.Gray,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Icon(
+                                imageVector = Icons.Default.AccessTime,
+                                contentDescription = "시간 선택",
+                                tint = Color.Gray
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Task 그룹 드롭다운
+                Text(
+                    text = "Task 그룹",
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(InputBackground)
+                        .clickable(enabled = groupList.isNotEmpty()) {
+                            isGroupDropdownExpanded = true
+                        }
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(
+                            text = selectedGroupName,
+                            color = if (selectedGroupId != null) Color.Black else Color.Gray
+                        )
+                        Icon(
+                            imageVector = Icons.Default.ArrowDropDown,
+                            contentDescription = "그룹 선택",
+                            tint = Color.Gray
+                        )
+                    }
+
+                    DropdownMenu(
+                        expanded = isGroupDropdownExpanded,
+                        onDismissRequest = { isGroupDropdownExpanded = false }
+                    ) {
+                        if (isGroupLoading) {
+                            DropdownMenuItem(
+                                text = { Text("그룹 로딩 중...") },
+                                onClick = { }
+                            )
+                        } else if (!groupError.isNullOrBlank()) {
+                            DropdownMenuItem(
+                                text = { Text("그룹 로드 실패: $groupError") },
+                                onClick = { }
+                            )
+                        } else if (groupList.isEmpty()) {
+                            DropdownMenuItem(
+                                text = { Text("가입된 그룹이 없습니다.") },
+                                onClick = { }
+                            )
+                        } else {
+                            groupList.forEach { group ->
+                                DropdownMenuItem(
+                                    text = { Text(group.name) },
+                                    onClick = {
+                                        selectedGroupId = group.groupId
+                                        selectedGroupName = group.name
+                                        isGroupDropdownExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // Task 생성 에러 메시지
+                if (!taskError.isNullOrBlank()) {
+                    Text(
+                        text = taskError!!,
+                        color = Color.Red,
+                        fontSize = 12.sp
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                // Task 추가 버튼
+                Button(
+                    onClick = {
+                        val groupId = selectedGroupId ?: return@Button
+
+                        // description은 현재 TaskViewModel 시그니처에 없어서,
+                        // 우선 title, groupId, dueDate, priority만 반영.
+                        taskViewModel.createTask(
+                            groupId = groupId,
+                            title = taskName,
+                            assignedToUid = "", // 현재는 할당 사용자 선택 UI가 없으므로 빈 값
+                            dueDate = dueDate,
+                            priority = 2 // 기본 우선순위
+                        )
+
+                        onTaskCreated()
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp),
+                    enabled = isCreateEnabled && !isTaskLoading,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = TaskFlowGreen,
+                        disabledContainerColor = TaskFlowGreen.copy(alpha = 0.4f)
+                    ),
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Text(
+                        text = "Task 추가",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+/**
+ * Figma 스타일에 맞춘 공통 입력 박스 (BasicTextField 기반)
+ */
+@Composable
+private fun TaskFlowInputBox(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    singleLine: Boolean,
+    modifier: Modifier = Modifier,
+    minHeight: Dp = 0.dp,
+    textStyle: TextStyle = MaterialTheme.typography.bodyMedium.copy(
+        color = Color.Black,
+        fontSize = 14.sp
+    )
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = singleLine,
+        textStyle = textStyle,
+        modifier = modifier.fillMaxWidth(),
+        decorationBox = { innerTextField ->
+            Box(
+                modifier = Modifier
+                    .background(InputBackground, RoundedCornerShape(10.dp))
+                    .then(
+                        if (minHeight > 0.dp) Modifier.heightIn(min = minHeight)
+                        else Modifier
+                    )
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                contentAlignment = Alignment.TopStart
+            ) {
+                if (value.isEmpty()) {
+                    Text(
+                        text = placeholder,
+                        style = textStyle.copy(color = Color.Gray)
+                    )
+                }
+                innerTextField()
+            }
+        }
+    )
+}
+
+
+


### PR DESCRIPTION
📌 AddTaskScreen 기능 개발 – 새 Task 생성 UI & 그룹/기한 선택 로직 (MVVM 기반)

---

### ✅ 개요 (Overview)

이번 PR에서는 **새로운 Task를 생성하는 AddTaskScreen**을 추가하고,
`TaskViewModel`과 `GroupViewModel`을 연동하여 **Task 생성 + 그룹 선택 + 마감 기한 설정**이 가능한 화면을 구현했습니다.

UI는 Figma 시안을 최대한 반영했고, 모든 비즈니스 로직은 ViewModel에 두고
화면은 **상태(StateFlow) 관찰 + 콜백 호출만 담당하는 MVVM View 역할**로 설계했습니다.

---

### 🔧 주요 변경 사항 (Key Changes)

#### 1. AddTaskScreen Composable 구현

* **Composable:** `AddTaskScreen`

* **패키지:** `com.ippo.taskflow.screen`

* **파라미터 계약:**

  * `taskViewModel: TaskViewModel` – Task 생성, 로딩/에러 상태 관리
  * `groupViewModel: GroupViewModel` – 사용자가 속한 그룹 목록 제공
  * `onTaskCreated: () -> Unit` – Task 생성 성공 후 이전 화면으로 복귀
  * `onNavigateBack: () -> Unit` – 상단 뒤로가기 버튼

* **로컬 UI 상태 (rememberSaveable):**

  * `taskName`: Task 이름
  * `taskDescription`: Task 설명
  * `selectedDateText`: 선택된 날짜 표시용 `"yyyy.MM.dd"` 문자열
  * `selectedTimeText`: 선택된 시간 표시용 `"HH:mm"` 문자열
  * `dueDate: Date?`: 실제 마감 기한(날짜+시간) 객체
  * `selectedGroupId: String?`: 선택된 그룹 ID
  * `selectedGroupName: String`: 드롭다운에 표시되는 그룹 이름
  * `isGroupDropdownExpanded`: 그룹 드롭다운 열림/닫힘 상태

* **ViewModel 상태 관찰:**

  * `groupViewModel.groupList`, `isLoading`, `error` → 그룹 드롭다운 렌더링 시 사용
  * `taskViewModel.isLoading`, `error` → “Task 추가” 버튼 상태 및 에러 메시지 표시

* **버튼 활성화 조건:**

  ```kotlin
  val isCreateEnabled = taskName.isNotBlank() && selectedGroupId != null
  ```

  * Task 이름과 그룹이 모두 선택되었을 때만 “Task 추가” 버튼 활성화

---

#### 2. 날짜/시간 선택 UI – DatePickerDialog & TimePickerDialog 연동

* Figma에 나온 **캘린더 아이콘 / 시계 아이콘이 있는 박스 형태**로 구현
* 내부 동작:

  * 날짜 박스 클릭 → `DatePickerDialog` 호출
  * 시간 박스 클릭 → `TimePickerDialog` 호출
  * 사용자가 연/월/일, 시/분을 선택하면 내부 `Calendar`를 갱신하고 `dueDate`를 업데이트

```kotlin
DatePickerDialog(
    context,
    { _, y, m, d ->
        calendar.set(Calendar.YEAR, y)
        calendar.set(Calendar.MONTH, m)
        calendar.set(Calendar.DAY_OF_MONTH, d)
        dueDate = calendar.time
        selectedDateText = SimpleDateFormat("yyyy.MM.dd", Locale.getDefault()).format(calendar.time)
    },
    year, month, day
).show()
```

```kotlin
TimePickerDialog(
    context,
    { _, h, m ->
        calendar.set(Calendar.HOUR_OF_DAY, h)
        calendar.set(Calendar.MINUTE, m)
        dueDate = calendar.time
        selectedTimeText = SimpleDateFormat("HH:mm", Locale.getDefault()).format(calendar.time)
    },
    hour, minute, true
).show()
```

* 선택된 값은 각각 `"날짜"`, `"시간"` placeholder를 대체해서 표시되며,
  **실제 Firestore Task는 `dueDate: Date?` 필드로 저장**됩니다.

---

#### 3. 그룹 선택 드롭다운 – GroupViewModel 연동

* 화면 진입 시:

  ```kotlin
  LaunchedEffect(Unit) {
      groupViewModel.loadGroups()
  }
  ```

  를 통해, 현재 사용자 UID를 기준으로 사용자가 속한 그룹 목록을 로드.

* 드롭다운 UI 동작:

  * `groupViewModel.groupList`를 `collectAsState()`로 관찰
  * 로딩 중 → “그룹 로딩 중…” 항목 노출
  * 에러 발생 → “그룹 로드 실패: ...” 항목 노출
  * 그룹이 없을 경우 → “가입된 그룹이 없습니다.” 표시
  * 그룹이 있을 경우 → 각 `Group`의 `name`을 DropdownMenuItem으로 렌더링

* 항목 선택 시:

  ```kotlin
  selectedGroupId = group.groupId
  selectedGroupName = group.name
  isGroupDropdownExpanded = false
  ```

* 드롭다운 박스 자체는 AddGroupScreen과 비슷한 스타일의 **연회색 라운드 박스 + 오른쪽 화살표 아이콘**으로 구현했습니다.

---

#### 4. Task 생성 로직 – TaskViewModel.createTask 연동

“Task 추가” 버튼 클릭 시:

```kotlin
Button(
    onClick = {
        val groupId = selectedGroupId ?: return@Button

        taskViewModel.createTask(
            groupId = groupId,
            title = taskName,
            assignedToUid = "",   // 현재는 담당자 선택 UI가 없으므로 빈 문자열
            dueDate = dueDate,
            priority = 2          // 기본 우선순위 2로 설정
        )

        onTaskCreated()
    },
    ...
)
```

* `TaskViewModel.createTask` 시그니처를 그대로 활용:

  * `groupId`: 드롭다운에서 선택한 그룹 ID
  * `title`: Task 이름
  * `assignedToUid`: 아직 담당자 선택 UI가 없기 때문에 현재는 빈 문자열
  * `dueDate`: DatePicker/TimePicker에서 선택한 값(없으면 null)
  * `priority`: 기본값 2(중간 정도)로 고정

> 🔎 **현재 Task 데이터 모델에는 description 필드가 있지만**,
> `createTask` 함수 시그니처에는 아직 description 인자가 없어서
> `taskDescription` 입력값은 Firestore에 바로 저장되지는 않습니다.
> (이 부분은 추후 `createTask` 시그니처 확장 또는 별도 update 로직을 추가하는 방향으로 개선 여지가 있습니다.)

---

#### 5. Figma 스타일 반영 – BasicTextField 기반 인풋 박스 재사용

* AddGroupScreen에서 사용했던 `TaskFlowInputBox`를 재사용해서,

  * Task 이름
  * Task 설명
    입력 UI를 구성.

* 특징:

  * `BasicTextField + decorationBox` 조합
  * 연회색 배경 + 라운드 + placeholder 텍스트
  * 포커스 테두리 변화 없음 → Figma 시안과 동일한 “그냥 박스” 느낌.

Task 이름은 `singleLine = true`,
설명은 `singleLine = false`, `minHeight = 100.dp`로 멀티라인 입력 지원.

---

### ⚠ 명세서와 아직 100% 일치하지 않는 부분

1. **Task 설명(description) 저장**

   * 명세서 상으로는 Task 생성 시 “이름 + 설명 + 기한 + 소속 그룹”을 받도록 되어 있음.
   * UI에서는 `taskDescription`을 입력받고 있지만,
   * 현재 `TaskViewModel.createTask(groupId, title, assignedToUid, dueDate, priority)` 시그니처에는 `description`이 없어,
     **설명 값이 Firestore `Task.description` 필드에 실제로 저장되지는 않는 상태**입니다.

   👉 이 부분은 추후에:

   * `createTask` 함수를 `createTask(groupId, title, description, assignedToUid, dueDate, priority)`처럼 확장하거나,
   * Task 생성 후 별도 `updateTaskDescription(taskId, description)` 같은 형태로 보완하는 개선이 필요합니다.

2. **담당자(assignedTo) 선택 UI**

   * 명세서에는 직접적인 언급은 없었지만, Task 모델에는 `assignedToUid` 필드가 존재.
   * 현재 화면은 담당자 선택 UI가 없고, `assignedToUid = ""`로 생성하고 있습니다.
   * 추후 그룹 멤버 목록을 기반으로 “담당자 선택 드롭다운”을 추가하는 확장 포인트로 남겨두었습니다.

---

### 🔍 테스트 사항 (Test & Verification)

✔ **UI 동작 확인**

* Task 이름/설명/날짜/시간/그룹 입력 및 선택 동작 확인
* 날짜/시간 필드 클릭 시 각각 DatePicker / TimePicker가 정상적으로 뜨는지 확인
* 필수값(이름 + 그룹) 미입력 시 “Task 추가” 버튼 비활성화되는지 확인

✔ **ViewModel 연동**

* `groupViewModel.loadGroups()` 호출 후 그룹 목록이 드롭다운에 정상 표기되는지 확인
* 그룹이 없는 계정에서 “가입된 그룹이 없습니다.” 표시되는지 확인
* `taskViewModel.createTask` 호출 후 Firestore `tasks` 컬렉션에 새 문서가 생성되는지 확인

✔ **네비게이션 플로우**

* 뒤로가기 버튼 → `onNavigateBack()` 콜백 호출 시 이전 화면으로 정상 복귀
* “Task 추가” 버튼 → `onTaskCreated()` 콜백 호출로 상위 NavHost에서 popBackStack 처리되는지 확인

---

### 📝 리뷰 요청 사항 (Reviewer Notes)

1. **description 처리 방식에 대한 의견**

   * 현재는 `taskDescription` 입력값이 저장되지 않고 있습니다.
   * `TaskViewModel.createTask` 시그니처 확장 vs. 후속 업데이트 API 추가 중 어떤 방향이 더 자연스러운지 의견 부탁드립니다.

2. **담당자(assignedTo) 선택 UX**

   * 지금은 `assignedToUid`를 빈 문자열로 생성하고 있는데,
   * 향후 그룹 멤버 기반으로 담당자 드롭다운을 추가하는 방향에 대해 팀 의견을 듣고 싶습니다.

3. **날짜/시간 선택 로직**

   * DatePicker + TimePicker로 `Calendar`를 한 번에 업데이트하고 `dueDate`를 관리하는 현재 방식이 괜찮은지,
   * 또는 “날짜만 필수, 시간은 선택” 같은 정책이 필요하다면 그에 맞춘 UX 변경이 필요할지 검토 부탁드립니다.

4. **에러/로딩 처리 흐름**

   * 현재는 Task 생성 버튼 클릭 직후 `onTaskCreated()`를 호출하고 있어,
     실제 Firestore 저장 성공 여부와는 약간 분리된 상태입니다.
   * `TaskViewModel`에 “성공 플래그”를 두고, 그 값이 true가 될 때 화면을 닫도록 하는 구조로 변경하는 것에 대한 의견 부탁드립니다.
