### PR TITLE
add: AlertScreen.kt

### DIFF
--- a/app/src/main/java/com/ippo/taskflow/activity/MainActivity.kt
+++ b/app/src/main/java/com/ippo/taskflow/activity/MainActivity.kt
@@ -216,12 +216,32 @@ fun MainAppNavHost(
             SettingScreen(
                 authViewModel = authViewModel,
                 onNavigateBack = { navController.popBackStack() },
-                onNavigateToLogin = { authViewModel.signOut() }, // 로그아웃 시 AuthNavHost로 전환됨
-                onNavigateToProfileSetting = { navController.navigate(Destinations.PROFILE_SETTING_ROUTE) },
+                onNavigateToLogin = { authViewModel.signOut() },
+
+                onNavigateToProfileSetting = {
+                    navController.navigate(Destinations.PROFILE_SETTING_ROUTE)
+                },
                 onNavigateToSecurity = { /* TODO */ },
                 onNavigateToTheme = { /* TODO */ },
                 onNavigateToAbout = { /* TODO */ },
-                onNavigateToEtc = { /* TODO */ }
+                onNavigateToEtc = { /* TODO */ },
+
+                // ✅ 추가된 하단 네비게이션 연결
+                onNavigateToMain = {
+                    navController.navigate(Destinations.HOME_ROUTE) {
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToGroups = {
+                    navController.navigate(Destinations.GROUPS_ROUTE) {
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToProfile = {
+                    navController.navigate(Destinations.PROFILE_ROUTE) {
+                        launchSingleTop = true
+                    }
+                }
             )
         }
 

--- a/app/src/main/java/com/ippo/taskflow/mvvm/model/AppNotification.kt
+++ b/app/src/main/java/com/ippo/taskflow/mvvm/model/AppNotification.kt
@@ -1,0 +1,13 @@
+package com.ippo.taskflow.mvvm.model
+
+data class AppNotification(
+    val id: String = "",
+    val type: String = "CHAIN",          // "CHAIN" | "DEADLINE"
+    val message: String = "",
+    val dateText: String = "",
+    val createdAt: Long = 0L,
+    val isRead: Boolean = false,
+    val taskId: String? = null,
+    val groupId: String? = null,
+    val dedupeKey: String? = null
+)

--- a/app/src/main/java/com/ippo/taskflow/mvvm/view/main_view/AlertScreen.kt
+++ b/app/src/main/java/com/ippo/taskflow/mvvm/view/main_view/AlertScreen.kt
@@ -1,0 +1,193 @@
+package com.ippo.taskflow.mvvm.view.main_view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.ippo.taskflow.mvvm.view_model.auth.AuthViewModel
+import com.ippo.taskflow.mvvm.view_model.notification.NotificationViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlertScreen(
+    authViewModel: AuthViewModel,
+    notificationViewModel: NotificationViewModel,
+    onBack: () -> Unit,
+
+    // ✅ 하단바 네비게이션 추가
+    onNavigateToMain: () -> Unit,
+    onNavigateToGroups: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+) {
+    val uid = authViewModel.userId
+    val state by notificationViewModel.state.collectAsState()
+
+    LaunchedEffect(uid) {
+        if (uid != null) notificationViewModel.start(uid)
+    }
+
+    Scaffold(
+        containerColor = Color.White, // ✅ 배경 흰색
+        topBar = {
+            TopAppBar(
+                title = { Text("알림", fontWeight = FontWeight.SemiBold) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            // ✅ Main/Setting과 동일 하단바
+            TaskFlowBottomNavBar(
+                onHomeClick = onNavigateToMain,
+                onMainClick = onNavigateToGroups,
+                onProfileClick = onNavigateToProfile
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(Color.White)
+        ) {
+
+            if (uid == null) {
+                Text("로그인이 필요합니다.", modifier = Modifier.align(Alignment.Center))
+                return@Box
+            }
+
+            if (state.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                return@Box
+            }
+
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                items(state.items) { n ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { notificationViewModel.markRead(uid, n.id) }
+                            .padding(horizontal = 16.dp, vertical = 12.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.Top
+                        ) {
+                            Text(
+                                text = n.message,
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.bodyLarge,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Text(
+                                text = n.dateText,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Divider(modifier = Modifier.padding(top = 12.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ----------------------
+// Preview (VM 없이 확인용)
+// ----------------------
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AlertScreenPreviewContent() {
+    val dummyNotifications = listOf(
+        Triple("지수님이 오늘의 할 일을 모두 완료했습니다!", "2025. 3. 19.", false),
+        Triple("“책 읽기” 완료일이 3일 남았습니다.", "2025. 3. 18.", false),
+        Triple("준하님이 오늘의 할 일을 모두 완료했습니다!", "2025. 3. 15.", true)
+    )
+
+    Scaffold(
+        containerColor = Color.White,
+        topBar = {
+            TopAppBar(
+                title = { Text("알림", fontWeight = FontWeight.SemiBold) },
+                navigationIcon = {
+                    IconButton(onClick = {}) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        bottomBar = {
+            TaskFlowBottomNavBar(
+                onHomeClick = {},
+                onMainClick = {},
+                onProfileClick = {}
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .background(Color.White),
+            contentPadding = PaddingValues(vertical = 8.dp)
+        ) {
+            items(dummyNotifications) { (message, date, _) ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        Text(
+                            text = message,
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodyLarge,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Text(
+                            text = date,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Divider(modifier = Modifier.padding(top = 12.dp))
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun AlertScreenPreview() {
+    MaterialTheme {
+        AlertScreenPreviewContent()
+    }
+}

--- a/app/src/main/java/com/ippo/taskflow/mvvm/view/main_view/SettingScreen.kt
+++ b/app/src/main/java/com/ippo/taskflow/mvvm/view/main_view/SettingScreen.kt
@@ -6,24 +6,22 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Group
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.ippo.taskflow.mvvm.view_model.auth.AuthViewModel
 
-// 💡 MVVM 표준: ViewModel + 네비게이션 액션만 인자로 받는다.
+
+// ✅ Main/Login/Register와 동일 톤
+private val TaskFlowLightGreen = Color(0xFFFFFFFF)
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingScreen(
@@ -35,11 +33,14 @@ fun SettingScreen(
     onNavigateToTheme: () -> Unit,
     onNavigateToAbout: () -> Unit,
     onNavigateToEtc: () -> Unit,
+
+    // ✅ 하단바 네비게이션(추가)
+    onNavigateToMain: () -> Unit,
+    onNavigateToGroups: () -> Unit,
+    onNavigateToProfile: () -> Unit,
 ) {
-    // 1. ViewModel의 상태를 관찰한다.
     val isLoading by authViewModel.isLoading.collectAsState(initial = false)
 
-    // 2. ViewModel → 순수 UI 레이어로 브릿지
     SettingScreenScaffold(
         isLoading = isLoading,
         onNavigateBack = onNavigateBack,
@@ -48,6 +49,12 @@ fun SettingScreen(
         onNavigateToTheme = onNavigateToTheme,
         onNavigateToAbout = onNavigateToAbout,
         onNavigateToEtc = onNavigateToEtc,
+
+        // ✅ bottom bar actions
+        onNavigateToMain = onNavigateToMain,
+        onNavigateToGroups = onNavigateToGroups,
+        onNavigateToProfile = onNavigateToProfile,
+
         onLogout = {
             if (!isLoading) {
                 authViewModel.signOut()
@@ -71,6 +78,12 @@ private fun SettingScreenScaffold(
     onNavigateToTheme: () -> Unit,
     onNavigateToAbout: () -> Unit,
     onNavigateToEtc: () -> Unit,
+
+    // ✅ 하단바 네비게이션(추가)
+    onNavigateToMain: () -> Unit,
+    onNavigateToGroups: () -> Unit,
+    onNavigateToProfile: () -> Unit,
+
     onLogout: () -> Unit,
 ) {
     Scaffold(
@@ -94,20 +107,23 @@ private fun SettingScreenScaffold(
             )
         },
         bottomBar = {
-            TaskFlowBottomNavBar()
+            // ✅ 공통 하단 네비게이션바 적용
+            TaskFlowBottomNavBar(
+                onHomeClick = onNavigateToMain,
+                onMainClick = onNavigateToGroups,
+                onProfileClick = onNavigateToProfile
+            )
         }
     ) { innerPadding ->
-        // 실제 Setting UI
         Column(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize()
-                .background(Color(0xFFF5F5F5)), // Figma 배경 느낌
+                .background(TaskFlowLightGreen),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Spacer(modifier = Modifier.height(8.dp))
 
-            // Figma 기준 카드 컨테이너
             Surface(
                 modifier = Modifier
                     .padding(horizontal = 16.dp)
@@ -136,10 +152,10 @@ private fun SettingScreenScaffold(
                     Divider()
                     SettingMenuItem(title = "기타", onClick = onNavigateToEtc)
                     Divider()
-                    // 🔴 로그아웃
                     SettingMenuItem(
-                        title = "로그아웃",
+                        title = if (isLoading) "처리 중..." else "로그아웃",
                         isDestructive = true,
+                        enabled = !isLoading,
                         onClick = onLogout
                     )
                 }
@@ -148,20 +164,17 @@ private fun SettingScreenScaffold(
     }
 }
 
-/**
- * 단일 설정 항목 Composable
- * - Figma 리스트 아이템 느낌으로 패딩/폰트 맞춤
- */
 @Composable
 private fun SettingMenuItem(
     title: String,
     isDestructive: Boolean = false,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 20.dp, vertical = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -169,89 +182,26 @@ private fun SettingMenuItem(
             text = title,
             style = MaterialTheme.typography.bodyLarge.copy(
                 fontWeight = FontWeight.Medium,
-                color = if (isDestructive)
-                    MaterialTheme.colorScheme.error
-                else
-                    MaterialTheme.colorScheme.onSurface
+                color = when {
+                    !enabled -> Color.Gray
+                    isDestructive -> MaterialTheme.colorScheme.error
+                    else -> MaterialTheme.colorScheme.onSurface
+                }
             ),
             modifier = Modifier.weight(1f)
         )
-        // ▶ 우측 화살표(Placeholder) — 나중에 아이콘 리소스로 교체 가능
         Text(
             text = "›",
-            style = MaterialTheme.typography.bodyLarge
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (enabled) Color.Black else Color.Gray
         )
     }
 }
 
-/**
- * DailyTaskScreen 과 동일하게 사용할 하단 네비게이션 바 (Home / Group / Profile)
- * - 실제 네비게이션 람다는 NavHost 쪽에서 교체 예정.
- */
-@Composable
-private fun TaskFlowBottomNavBar() {
-    Surface(
-        color = Color(0xFF9CFFC4), // Figma 하단 그린 톤과 비슷하게
-        tonalElevation = 3.dp,
-        shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp)
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(64.dp)
-                .padding(horizontal = 48.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            BottomNavItem(
-                icon = Icons.Default.Home,
-                label = "Home",
-                onClick = { /* TODO: Home 이동 */ }
-            )
-            BottomNavItem(
-                icon = Icons.Default.Group,
-                label = "Group",
-                onClick = { /* TODO: Group 이동 */ }
-            )
-            BottomNavItem(
-                icon = Icons.Default.Person,
-                label = "Profile",
-                onClick = { /* TODO: Profile 이동 */ }
-            )
-        }
-    }
-}
-
-@Composable
-private fun BottomNavItem(
-    icon: ImageVector,
-    label: String,
-    onClick: () -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .clip(RoundedCornerShape(16.dp))
-            .clickable(onClick = onClick)
-            .padding(vertical = 6.dp, horizontal = 8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Icon(imageVector = icon, contentDescription = label)
-        Text(
-            text = label,
-            style = MaterialTheme.typography.labelSmall,
-            fontWeight = FontWeight.Medium
-        )
-    }
-}
-
-/**
- * 🖼 Preview용 Composable
- * - ViewModel 없이 순수 UI만 확인
- */
 @Preview(showBackground = true)
 @Composable
 private fun SettingScreenPreview() {
-    MaterialTheme { // 프로젝트 테마가 있으면 여기서 감싸도 됨 (ex. TaskFlowTheme)
+    MaterialTheme {
         SettingScreenScaffold(
             isLoading = false,
             onNavigateBack = {},
@@ -260,6 +210,9 @@ private fun SettingScreenPreview() {
             onNavigateToTheme = {},
             onNavigateToAbout = {},
             onNavigateToEtc = {},
+            onNavigateToMain = {},
+            onNavigateToGroups = {},
+            onNavigateToProfile = {},
             onLogout = {}
         )
     }

--- a/app/src/main/java/com/ippo/taskflow/mvvm/view/main_view/TaskFlowBottomNavBar.kt
+++ b/app/src/main/java/com/ippo/taskflow/mvvm/view/main_view/TaskFlowBottomNavBar.kt
@@ -1,0 +1,60 @@
+package com.ippo.taskflow.mvvm.view.main_view
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.ippo.taskflow.R
+
+@Composable
+fun TaskFlowBottomNavBar(
+    onHomeClick: () -> Unit,
+    onMainClick: () -> Unit,
+    onProfileClick: () -> Unit,
+) {
+    Surface(
+        tonalElevation = 8.dp,
+        shadowElevation = 8.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color(0xFFACFFC1))
+                .padding(horizontal = 40.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+
+            IconButton(onClick = onHomeClick) {
+                Image(
+                    painter = painterResource(R.drawable.ic_home),
+                    contentDescription = "Home",
+                    modifier = Modifier.size(50.dp)
+                )
+            }
+
+            IconButton(onClick = onMainClick) {
+                Image(
+                    painter = painterResource(R.drawable.ic_taskflow),
+                    contentDescription = "TaskFlow",
+                    modifier = Modifier.size(50.dp)
+                )
+            }
+
+            IconButton(onClick = onProfileClick) {
+                Image(
+                    painter = painterResource(R.drawable.ic_profile),
+                    contentDescription = "Profile",
+                    modifier = Modifier.size(50.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ippo/taskflow/mvvm/view_model/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/ippo/taskflow/mvvm/view_model/notification/NotificationViewModel.kt
@@ -1,0 +1,67 @@
+package com.ippo.taskflow.mvvm.view_model.notification
+
+import androidx.lifecycle.ViewModel
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.Query
+import com.ippo.taskflow.mvvm.model.AppNotification
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+data class NotificationState(
+    val isLoading: Boolean = false,
+    val items: List<AppNotification> = emptyList(),
+    val error: String? = null
+)
+
+class NotificationViewModel : ViewModel() {
+
+    private val db = FirebaseFirestore.getInstance()
+
+    private val _state = MutableStateFlow(NotificationState(isLoading = true))
+    val state: StateFlow<NotificationState> = _state
+
+    private var listener: ListenerRegistration? = null
+
+    override fun onCleared() {
+        super.onCleared()
+        listener?.remove()
+    }
+
+    fun start(uid: String) {
+        _state.value = _state.value.copy(isLoading = true, error = null)
+        listener?.remove()
+
+        listener = db.collection("users").document(uid)
+            .collection("notifications")
+            .orderBy("createdAt", Query.Direction.DESCENDING)
+            .addSnapshotListener { snap, e ->
+                if (e != null) {
+                    _state.value = _state.value.copy(isLoading = false, items = emptyList(), error = e.message)
+                    return@addSnapshotListener
+                }
+
+                val list = snap?.documents?.map { d ->
+                    AppNotification(
+                        id = d.id,
+                        type = d.getString("type") ?: "CHAIN",
+                        message = d.getString("message") ?: "",
+                        dateText = d.getString("dateText") ?: "",
+                        createdAt = d.getLong("createdAt") ?: 0L,
+                        isRead = d.getBoolean("isRead") ?: false,
+                        taskId = d.getString("taskId"),
+                        groupId = d.getString("groupId"),
+                        dedupeKey = d.getString("dedupeKey")
+                    )
+                } ?: emptyList()
+
+                _state.value = _state.value.copy(isLoading = false, items = list, error = null)
+            }
+    }
+
+    fun markRead(uid: String, notificationId: String) {
+        db.collection("users").document(uid)
+            .collection("notifications").document(notificationId)
+            .update("isRead", true)
+    }
+}

--- a/app/src/main/java/com/ippo/taskflow/mvvm/view_model/utils/ViewModelFactory.kt
+++ b/app/src/main/java/com/ippo/taskflow/mvvm/view_model/utils/ViewModelFactory.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.ippo.taskflow.mvvm.view_model.auth.AuthViewModel
 import com.ippo.taskflow.mvvm.view_model.group.GroupViewModel
 import com.ippo.taskflow.mvvm.view_model.task.TaskViewModel
+import com.ippo.taskflow.mvvm.view_model.notification.NotificationViewModel
 
 class ViewModelFactory(
     private val authViewModel: AuthViewModel,
@@ -16,6 +17,11 @@ class ViewModelFactory(
         if (modelClass.isAssignableFrom(GroupViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
             return GroupViewModel(authViewModel, taskViewModel) as T
+        }
+
+        if (modelClass.isAssignableFrom(NotificationViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return NotificationViewModel() as T
         }
 
         // 🚨 이 팩토리가 생성할 수 없는 다른 ViewModel 요청이 들어오면 오류를 반환합니다.


### PR DESCRIPTION
📌 PR 제목

AlertScreen 추가 및 공통 하단 네비게이션(TaskFlowBottomNavBar) 구조 정비

⸻

🧭 변경 배경

기존 알림 기능이 화면/네비게이션 구조에 포함되어 있지 않았고,
하단 네비게이션이 화면별로 중복 구현되어 컴포넌트 충돌 및 재사용성 저하 문제가 있었습니다.
이를 해결하기 위해 알림 화면과 관련 ViewModel을 추가하고,
하단 네비게이션을 단일 공통 컴포넌트로 분리·정비했습니다.

⸻

✅ 주요 변경 사항

1. 알림 기능 추가
	•	AlertScreen.kt
	•	알림 목록 UI 구현
	•	읽음 처리(markRead) 연동
	•	TopAppBar + 공통 하단 네비게이션 적용
	•	AppNotification.kt
	•	알림 도메인 모델 정의
	•	NotificationViewModel.kt
	•	알림 상태 관리(StateFlow)
	•	사용자 UID 기준 알림 로드/읽음 처리 로직 구현

⸻

2. 공통 하단 네비게이션 컴포넌트 생성
	•	TaskFlowBottomNavBar.kt 신규 생성
	•	Home / Group / Profile 3개 아이콘 기반
	•	모든 메인 화면에서 동일 UI/동작 보장
	•	PNG 아이콘 리소스 사용
	•	단일 정의로 중복/충돌 문제 해결

⸻

3. 설정 화면 네비게이션 구조 통일
	•	SettingScreen.kt
	•	기존 개별 하단바 제거
	•	TaskFlowBottomNavBar 사용하도록 수정
	•	화면 배경은 White, 하단바만 Green 유지

⸻

4. 앱 전역 네비게이션 수정
	•	MainActivity.kt
	•	AlertScreen 라우트 추가
	•	하단 네비게이션 이동 흐름 정리
	•	AlertScreen → Home / Group / Profile 이동 가능하도록 연결
	•	ViewModelFactory.kt
	•	NotificationViewModel 생성 로직 추가

⸻

🧩 구조 개선 포인트
	•	하단 네비게이션 단일 소스화
	•	화면 간 UI/네비게이션 일관성 확보
	•	View / ViewModel 책임 분리 명확화
	•	이후 화면 추가 시 하단바 재사용 가능

⸻

🔍 테스트 포인트
	•	로그인 상태에서 알림 화면 진입 정상 여부
	•	알림 클릭 시 읽음 처리 정상 동작
	•	Alert / Setting / Main 화면에서 하단 네비게이션 표시 여부
	•	하단바 클릭 시 각 화면(Home, Group, Profile) 정상 이동

⸻

⚠️ 참고 사항
	•	하단 네비게이션은 TaskFlowBottomNavBar.kt 단일 파일만 사용
	•	동일 이름의 네비게이션 컴포넌트 추가 금지 (충돌 방지)

